### PR TITLE
fix: wrong duration when user has multiple sessions with same internal id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bbbevents (1.5.0)
+    bbbevents (1.5.1)
       nokogiri
 
 GEM

--- a/lib/bbbevents/recording.rb
+++ b/lib/bbbevents/recording.rb
@@ -234,7 +234,13 @@ module BBBEvents
           unless joins_lefts_arr_sorted_length == i
             # Take the next event as the left event for this current event
             next_event = joins_lefts_arr_sorted[i + 1]
-            left_event = {:timestamp => next_event[:timestamp], :userid => cur_event[:userid], :event => :left}
+            
+            # only match if it's the same userId
+            if cur_event[:join][:userid] == next_event[:join][:userid]
+              left_event = {:timestamp => next_event[:join][:timestamp], :userid => cur_event[:join][:userid] , :event => :left}
+            else
+              left_event = {:timestamp => @finish, :userid => cur_event[:join][:userid], :event => :left}
+            end
 
             cur_event[:left] = left_event
           end

--- a/lib/bbbevents/version.rb
+++ b/lib/bbbevents/version.rb
@@ -1,3 +1,3 @@
 module BBBEvents
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end


### PR DESCRIPTION
When the user has multiple sessions with and without the same internal id, the duration time was wrong due to considering the wrong left time for the session.

Bump version.

Before:
![image](https://github.com/user-attachments/assets/14f3616a-98b2-4080-ad18-70b56045351c)


After:
![image](https://github.com/user-attachments/assets/707b464f-2147-4f21-96f9-2099d5fa4754)

Related to https://github.com/mconf/mconf-tracker/issues/1898